### PR TITLE
Add Causal Policy Analysis Framework for PDM

### DIFF
--- a/initial_processor_causal_policy
+++ b/initial_processor_causal_policy
@@ -511,7 +511,7 @@ class PolicyDocumentAnalyzer:
             if len(relevant_sims) >= self.config.min_evidence_chunks:
                 evidence = self.bayesian.integrate_evidence(
                     relevant_sims,
-                    [chunks[i] for i in np.where(relevant_mask)[0]]
+                    relevant_chunks
                 )
             else:
                 evidence = self.bayesian._null_evidence()


### PR DESCRIPTION
This file implements a Causal Policy Analysis Framework tailored for Colombian Municipal Development Plans, incorporating state-of-the-art semantic processing and Bayesian evidence integration.